### PR TITLE
Revert "bumped bundler version"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,4 +37,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.0.2
+   1.17.2


### PR DESCRIPTION
Reverts Cisco-AMP/invalid_json_error_middleware#5